### PR TITLE
Fix AppCenter error

### DIFF
--- a/data/com.github.eexpress.cairo-timer.appdata.xml
+++ b/data/com.github.eexpress.cairo-timer.appdata.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2020 Eexpress <[eexpss@gmail.com]> -->
 <component type="desktop">


### PR DESCRIPTION
Humor me and try this PR out. If so, I feel really bad for you, as all I did was remove a blank line from the `appdata.xml` file. Before, it gave me this warning:

```
** (io.elementary.appcenter:11472): WARNING **: 14:19:51.260: Application.vala:168: Failed to load local AppStream XML file: Could not parse XML data: Entity: line 2: parser error : XML declaration allowed only at the start of the document
<?xml version="1.0" encoding="UTF-8"?>
     ^
```

Afterwards, it shows up:

![Shows up now](https://user-images.githubusercontent.com/28582777/80019238-3280e600-84a5-11ea-90f2-765e6f1decb8.png)


Also, helpful developer trick:

You can test your `appdata.xml` file in AppCenter locally by doing `io.elementary.appcenter -l path/to/your/appdata.xml`

However you may need to kill the process before doing this `killall io.elementary.appcenter`